### PR TITLE
Add a new hash function: iterated multiply-shift.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(asm)]
 #![feature(test)]
 #![cfg_attr(test, feature(hashmap_hasher))]
 #![allow(unused_imports, dead_code)]
@@ -10,6 +11,8 @@ extern crate fnv as _fnv;
 extern crate blake2_rfc;
 extern crate test;
 extern crate regex;
+
+mod multiply_shift;
 
 use std::process::Command;
 use std::io::Result as IoResult;
@@ -115,6 +118,7 @@ macro_rules! hash_benches {
         use farmhash::FarmHasher as Farm;
         use std::hash::Hasher;
         use std::collections::hash_state::{DefaultState, HashState};
+        use multiply_shift::HornerHasher;
 
         use std::collections::HashMap;
         use test::{black_box, Bencher};
@@ -153,7 +157,7 @@ macro_rules! hash_benches {
                 map
             });
         }
-/*
+
         #[bench] fn bytes_000000001(b: B) { hasher_bench::<$Impl>(b, 1) }
         #[bench] fn bytes_000000002(b: B) { hasher_bench::<$Impl>(b, 2) }
         #[bench] fn bytes_000000004(b: B) { hasher_bench::<$Impl>(b, 4) }
@@ -172,8 +176,8 @@ macro_rules! hash_benches {
         #[bench] fn bytes_000032000(b: B) { hasher_bench::<$Impl>(b, 32_000) }
         #[bench] fn bytes_000064000(b: B) { hasher_bench::<$Impl>(b, 64_000) }
         #[bench] fn bytes_001000000(b: B) { hasher_bench::<$Impl>(b, 1_000_000) }
-*/
 
+/*
         #[bench] fn mapcount_000000001(b: B) { map_bench::<$Impl>(b, 1) }
         #[bench] fn mapcount_000000002(b: B) { map_bench::<$Impl>(b, 2) }
         #[bench] fn mapcount_000000004(b: B) { map_bench::<$Impl>(b, 4) }
@@ -192,6 +196,7 @@ macro_rules! hash_benches {
         #[bench] fn mapcount_000032000(b: B) { map_bench::<$Impl>(b, 32_000) }
         #[bench] fn mapcount_000064000(b: B) { map_bench::<$Impl>(b, 64_000) }
         // #[bench] fn mapcount_001000000(b: B) { map_bench::<$Impl>(b, 1_000_000) }
+*/
     }
 }
 
@@ -199,6 +204,7 @@ macro_rules! hash_benches {
 #[cfg(test)] mod xx { hash_benches!{Xx} }
 #[cfg(test)] mod farm { hash_benches!{Farm} }
 #[cfg(test)] mod fnv { hash_benches!{Fnv} }
+#[cfg(test)] mod horner { hash_benches!{HornerHasher} }
 
 // one day?
 
@@ -206,6 +212,7 @@ macro_rules! hash_benches {
 // #[cfg(test)] mod blake2s { hash_benches!{Blake2s} }
 // #[cfg(test)] mod murmur { hash_benches!{MurMur}}
 
+/*
 #[cfg(test)]
 mod btree {
     use std::collections::BTreeMap;
@@ -248,4 +255,4 @@ mod btree {
     // #[bench] fn mapcount_001000000(b: B) { map_bench(b, 1_000_000) }
 
 }
-
+*/

--- a/src/multiply_shift.rs
+++ b/src/multiply_shift.rs
@@ -1,0 +1,131 @@
+// String hashing by iterating Dietzfelbinger et al.'s multiply-shift
+// hashing. The resulting hash value can be used in hash tables by
+// shifting it right, but not by taking the low-order bits -- the
+// high-order bits are the higher-quality ones for use in
+// distinguishing the hashed keys.
+//
+// TODO: by using Woelfel's multiply-add-shift hashing, we can get the
+// lower order bits to be the most usable ones.
+//
+// TODO: accumulating four hash values at once increases the speed on
+// my machine, but it also makes the code more complex.
+
+use std::hash::Hasher;
+
+// This is called a "Horner" hasher because the iterated
+// multiply-shift operation resembles Horner's method for evaluating
+// polynomials. In fact, we are computing, more or less, 
+//
+// sum_i (h0 ^ i) \floor{xi * h / 2^64}
+//
+// where xi is the ith word of the key being hashed.
+// 
+// TODO: explain that equivalence in more detail.
+pub struct HornerHasher {
+    // A randomly-chosen odd 128-bit number. h0 holds the
+    // least-significant bits.
+    h0: u64,
+    h1: u64,
+    // The hash value we have accumulated so far.
+    result: u64,
+    // We accumulate 8 bytes, then update 'result'. accum holds those
+    // bytes in its least-significant bits. This can be thought of
+    // (and will be treated) as both a u64 and a [u8; 8].
+    accum: u64,
+    // The number of bytes we have seen so far
+    count: u64
+}
+
+impl Default for HornerHasher {
+    fn default() -> HornerHasher {
+        // h0 and h1 should be populated from a random source like
+        // rand::os::OsRng::next_u64, but this is done in the hash map
+        // constructor.
+        return HornerHasher {h0: 4167967182414233411, 
+                             h1: 15315631059493996859,
+                             result: 0, accum: 0, count: 0};
+    }
+}
+
+// multiply two 64-bit words and return the 64 most significant bits
+// of the 128-bit product.
+//
+// TODO: implement and test this on other architectures.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn hi64mul(x: u64, y: u64) -> u64 {
+    let _lo: u64; let hi: u64;
+    unsafe { asm!("mulq $3" 
+                  : "=rm" (_lo), "=r" (hi) 
+                  : "0rm" (x), "rm" (y) 
+                  : "cc" :); }
+    return hi;
+}
+
+// Multiply two 128-bit numbers and write 64 bits of the product to
+// 'result'. The bits written are those starting from the 64th least
+// significant bit (counting from 0) and going up. This is
+// multiply-shift hashing ala Dietzfelbinger et al.
+#[inline(always)]
+fn mult_hi128(result: &mut u64, accum: u64, h0: u64, h1: u64) {
+    *result = (accum.wrapping_mul(h0))
+        .wrapping_add(result.wrapping_mul(h1))
+        .wrapping_add(hi64mul(*result, h0))
+}
+
+impl Hasher for HornerHasher {
+    
+    fn finish(&self) -> u64 {
+        // Hashes any characters waiting in self.accum and also hashes
+        // with the length of the string to prevent engineered
+        // collisions by prepending '\000's to hashed keys.
+        let mut result: u64 = self.result;
+        if (self.count & 7) > 0 {
+            mult_hi128(&mut result, self.accum, self.h0, self.h1);
+        }
+        mult_hi128(&mut result, self.count, self.h0, self.h1);
+        return result;
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut i = 0;
+        
+        // Fill up self.accum if it is not full.
+        let accum = &mut self.accum as *mut u64 as *mut u8;
+        while (self.count & 7) > 0 && i < bytes.len() {
+            unsafe {
+                *(accum.offset((self.count & 7) as isize) as *mut u8) 
+                    = bytes[i]; 
+            }
+            i += 1;
+            self.count += 1;
+        }
+
+        self.count += (bytes.len() - i) as u64;
+
+        // If we touched self.accum, hash it and reset it.
+        if i > 0 {
+            mult_hi128(&mut self.result, self.accum, self.h0, self.h1);
+            self.accum = 0;
+        }
+        
+        // This is the main loop: for each 64-bits we pull from bytes,
+        // hash it into self.result.
+        while i + 7 < bytes.len() {
+            mult_hi128(&mut self.result, 
+                       unsafe {*(&bytes[i] as *const u8 as *const u64)}, 
+                       self.h0, 
+                       self.h1);
+            i += 8;
+        }
+        
+        // Add in the remaining characters to self.accum.
+        while i < bytes.len() {
+            unsafe { 
+                *(accum.offset((8 + i - bytes.len()) as isize) as *mut u8) 
+                    = bytes[i]; 
+            }
+            i += 1;
+        }
+    }
+}


### PR DESCRIPTION
This performs substantially faster than sip on my machine. However, it
is not cryptographically secure and requires the use of the higher
order bits of the hash value, rather than the lower order bits, as is
common practice.
