### PR TITLE
Stop depending on unstable intrinsics

### DIFF
--- a/src/multiply_shift.rs
+++ b/src/multiply_shift.rs
@@ -11,7 +11,7 @@
 // my machine, but it also makes the code more complex.
 
 
-use std::intrinsics::copy_nonoverlapping;
+use std::ptr::copy_nonoverlapping;
 //#[stable(feature = "rust1", since = "1.0.0")]
 //pub use intrinsics::copy_nonoverlapping;
 use std::hash::Hasher;


### PR DESCRIPTION
The intrinsics were accidentally made stable, but are fundamentally unstable. The stable wrappers are in `core::ptr` / `std::ptr`.

See https://github.com/rust-lang/rust/pull/57997